### PR TITLE
fix: default foreground color to Text

### DIFF
--- a/themes/frappe.json
+++ b/themes/frappe.json
@@ -2,7 +2,7 @@
 	"document": {
 	  "block_prefix": "\n",
 	  "block_suffix": "\n",
-	  "color": "#303446",
+	  "color": "#c6d0f5",
 	  "margin": 2
 	},
 	"block_quote": {

--- a/themes/latte.json
+++ b/themes/latte.json
@@ -2,7 +2,7 @@
 	"document": {
 	  "block_prefix": "\n",
 	  "block_suffix": "\n",
-	  "color": "#eff1f5",
+	  "color": "#4c4f69",
 	  "margin": 2
 	},
 	"block_quote": {

--- a/themes/macchiato.json
+++ b/themes/macchiato.json
@@ -2,7 +2,7 @@
   "document": {
     "block_prefix": "\n",
     "block_suffix": "\n",
-    "color": "#24273a",
+    "color": "#cad3f5",
     "margin": 2
   },
   "block_quote": {

--- a/themes/mocha.json
+++ b/themes/mocha.json
@@ -2,7 +2,7 @@
 	"document": {
 	  "block_prefix": "\n",
 	  "block_suffix": "\n",
-	  "color": "#1e1e2e",
+	  "color": "#cdd6f4",
 	  "margin": 2
 	},
 	"block_quote": {


### PR DESCRIPTION
it was Surface1 which is the background color in catppuccin terminal ports

examples below are with glow, the macchiato flavor of this glamour style, and the default macchiato xfce4-terminal port

### Current
![image](https://user-images.githubusercontent.com/46696318/219907307-2313029f-1d82-436f-9e37-00c16f9942c6.png)

### Proposed fix
![image](https://user-images.githubusercontent.com/46696318/219907314-83e74da8-1914-470e-8a97-98706e9efcd9.png)
